### PR TITLE
Add check for empty list of roots

### DIFF
--- a/spacy_entity_linker/TermCandidateExtractor.py
+++ b/spacy_entity_linker/TermCandidateExtractor.py
@@ -11,7 +11,10 @@ class TermCandidateExtractor:
                 yield candidate
 
     def _get_candidates_in_sent(self, sent, doc):
-        root = list(filter(lambda token: token.dep_ == "ROOT", sent))[0]
+        roots = list(filter(lambda token: token.dep_ == "ROOT", sent))
+        if len(roots) < 1:
+            return []
+        root = roots[0]
 
         excluded_children = []
         candidates = []


### PR DESCRIPTION
Currently, any document containing a sentence that spacy believes to be empty will cause an exception to be raised due to unsafe indexing into a list which may be empty. For example:

```
nlp = spacy.load("en_core_web_md")
nlp.add_pipe("entityLinker", last=True)

nlp("\n\n")
```

raises 
```
.../spacy_entity_linker/TermCandidateExtractor.py in _get_candidates_in_sent(self, sent, doc)
     12 
     13     def _get_candidates_in_sent(self, sent, doc):
---> 14         root = list(filter(lambda token: token.dep_ == "ROOT", sent))[0]
     15 
     16         excluded_children = []

IndexError: list index out of range

```

This PR fixes that.