### PR TITLE
Knowledge base links

### DIFF
--- a/downloadKnowledgeBase.sh
+++ b/downloadKnowledgeBase.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-wget "https://wikidatafiles.nyc3.digitaloceanspaces.com/Hosting/Hosting/SpacyEntityLinker/datafiles.tar.gz" -O /tmp/knowledge_base.tar.gz
+wget "https://huggingface.co/MartinoMensio/spaCy-entity-linker/resolve/main/knowledge_base.tar.gz" -O /tmp/knowledge_base.tar.gz
 tar -xzf /tmp/knowledge_base.tar.gz --directory ./data_spacy_entity_linker
 rm /tmp/knowledge_base.tar.gz

--- a/spacy_entity_linker/__main__.py
+++ b/spacy_entity_linker/__main__.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     command = sys.argv.pop(1)
 
     if command == "download_knowledge_base":
-        FILE_URL = "https://wikidatafiles.nyc3.digitaloceanspaces.com/Hosting/Hosting/SpacyEntityLinker/datafiles.tar.gz"
+        FILE_URL = "https://huggingface.co/MartinoMensio/spaCy-entity-linker/resolve/main/knowledge_base.tar.gz"
 
         OUTPUT_TAR_FILE = os.path.abspath(
             os.path.dirname(__file__)) + '/../data_spacy_entity_linker/wikidb_filtered.tar.gz'


### PR DESCRIPTION
Hi @egerber,
As shown in #11, users are having problems downloading the knowledge base from Digital Ocean Spaces. So I re-uploaded the file to a LFS in HuggingFace (https://huggingface.co/MartinoMensio/spaCy-entity-linker/resolve/main/knowledge_base.tar.gz) and updated the pointers in the python file and the bash script.

Best,
Martino

