### PR TITLE
Add test case to check whether empty root processing is correct.

### DIFF
--- a/tests/test_EntityLinker.py
+++ b/tests/test_EntityLinker.py
@@ -24,10 +24,15 @@ class TestEntityLinker(unittest.TestCase):
         self.nlp.remove_pipe("entityLinker")
 
     def test_empty_root(self):
+        # test empty lists of roots (#9)
         self.nlp.add_pipe("entityLinker", last=True)
 
         doc = self.nlp(
             'I was right."\n\n     "To that extent."\n\n     "But that was all."\n\n     "No, no, m')
+        for sent in doc.sents:
+            sent._.linkedEntities.pretty_print()
+        # empty document
+        doc = self.nlp('\n\n')
         for sent in doc.sents:
             sent._.linkedEntities.pretty_print()
 

--- a/tests/test_EntityLinker.py
+++ b/tests/test_EntityLinker.py
@@ -22,3 +22,13 @@ class TestEntityLinker(unittest.TestCase):
             sent._.linkedEntities.pretty_print()
 
         self.nlp.remove_pipe("entityLinker")
+
+    def test_empty_root(self):
+        self.nlp.add_pipe("entityLinker", last=True)
+
+        doc = self.nlp(
+            'I was right."\n\n     "To that extent."\n\n     "But that was all."\n\n     "No, no, m')
+        for sent in doc.sents:
+            sent._.linkedEntities.pretty_print()
+
+        self.nlp.remove_pipe("entityLinker")


### PR DESCRIPTION
This test case caused issues for me, using a combination of `spacy<=3.5` and `spacy_entity_linker==1.0.2`.  
Interestingly, I wasn't able to reproduce the error on an environment using the latest `spacy==3.5` version, but I'm not sure if this is due to conflicting path information on my end.