### PR TITLE
Linking entities to underlying spans

### DIFF
--- a/spacy_entity_linker/EntityLinker.py
+++ b/spacy_entity_linker/EntityLinker.py
@@ -24,7 +24,11 @@ class EntityLinker:
             entityCandidates = termCandidates.get_entity_candidates()
             if len(entityCandidates) > 0:
                 entity = classifier(entityCandidates)
+                # Add the entity to the sentence-level EntityCollection
                 entity.span.sent._.linkedEntities.append(entity)
+                # Also associate the token span with the entity
+                entity.span._.linkedEntities = entity
+                # And finally append to the document-level collection
                 entities.append(entity)
 
         doc._.linkedEntities = EntityCollection(entities)


### PR DESCRIPTION
So far, `EntityLinker` only allows access to the document-level or sentence-level `EntityCollection`s.
For me, a particularly useful pattern is direct access through arbitrary underlying `Span`s.

Span-level attributes are already possible in the library (thanks to the sentence-level support, because sentences in spacy are also just represented as a `Span`). This PR simply adds the individual `EntityElement` to its associated span.

Example usage:

```python
text = ""
nlp = spacy.load("en_core_web_sm")
nlp.add_pipe("entityLinker", last=True)
doc = nlp(text)

# Previously simply returned "None"
print(doc[2:4]._.linkedEntities)  # <EntityElement: ...>
```

This is also useful for mappings over entities extracted with spacy, as described in #18.  
One minor nitpick of my own change: Now, `._.linkedEntities` no longer returns a consistent type (previously always returned an `EntityCollection`, now also returns `EntityElement` in cases of spans.

Again, happy to discuss the necessity of this change for the library first :)  
Best,  
Dennis