### PR TITLE
Multiprocessing and serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,41 @@ each linked Entity is an object of type <code>EntityElement</code>. Each entity 
 - <code>get_description()</code> returns description from Wikidata
 - <code>get_id()</code> returns Wikidata ID
 - <code>get_label()</code> returns Wikidata label
-- <code>get_span(doc)</code> returns the span from the spacy document that contains the linked entity. You need to provide the current `doc` as argument, in order to receive an actual `spacy.tokens.Span` object, otherwise you will receive a SpanInfo emulating the behaviour of a Span
+- <code>get_span(doc)</code> returns the span from the spacy document that contains the linked entity. You need to provide the current `doc` as argument, in order to receive an actual `spacy.tokens.Span` object, otherwise you will receive a `SpanInfo` emulating the behaviour of a Span
 - <code>get_url()</code> returns the url to the corresponding Wikidata item
 - <code>pretty_print()</code> prints out information about the entity element
 - <code>get_sub_entities(limit=10)</code> returns EntityCollection of all entities that derive from the current
   entityElement (e.g. fruit -> apple, banana, etc.)
 - <code>get_super_entities(limit=10)</code> returns EntityCollection of all entities that the current entityElement
   derives from (e.g. New England Patriots -> Football Team))
+
+
+Usage of the `get_span` method with `SpanInfo`:
+
+```python
+import spacy
+nlp = spacy.load('en_core_web_md')
+nlp.add_pipe("entityLinker", last=True)
+text = 'Apple is competing with Microsoft.'
+doc = nlp(text)
+sents = list(doc.sents)
+ent = doc._.linkedEntities[0]
+
+# using the SpanInfo class
+span = ent.get_span()
+print(span.start, span.end, span.text) # behaves like a Span
+
+# check equivalence
+print(span == doc[0:1]) # True
+print(doc[0:1] == span) # TypeError: Argument 'other' has incorrect type (expected spacy.tokens.span.Span, got SpanInfo)
+
+# now get the real span
+span = ent.get_span(doc) # passing the doc instance here
+print(span.start, span.end, span.text)
+
+print(span == doc[0:1]) # True
+print(doc[0:1] == span) # True
+```
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ each linked Entity is an object of type <code>EntityElement</code>. Each entity 
 - <code>get_description()</code> returns description from Wikidata
 - <code>get_id()</code> returns Wikidata ID
 - <code>get_label()</code> returns Wikidata label
-- <code>get_span()</code> returns the span from the spacy document that contains the linked entity
+- <code>get_span(doc)</code> returns the span from the spacy document that contains the linked entity. You need to provide the current `doc` as argument, in order to receive an actual `spacy.tokens.Span` object
 - <code>get_url()</code> returns the url to the corresponding Wikidata item
 - <code>pretty_print()</code> prints out information about the entity element
 - <code>get_sub_entities(limit=10)</code> returns EntityCollection of all entities that derive from the current

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ each linked Entity is an object of type <code>EntityElement</code>. Each entity 
 - <code>get_description()</code> returns description from Wikidata
 - <code>get_id()</code> returns Wikidata ID
 - <code>get_label()</code> returns Wikidata label
-- <code>get_span(doc)</code> returns the span from the spacy document that contains the linked entity. You need to provide the current `doc` as argument, in order to receive an actual `spacy.tokens.Span` object
+- <code>get_span(doc)</code> returns the span from the spacy document that contains the linked entity. You need to provide the current `doc` as argument, in order to receive an actual `spacy.tokens.Span` object, otherwise you will receive a SpanInfo emulating the behaviour of a Span
 - <code>get_url()</code> returns the url to the corresponding Wikidata item
 - <code>pretty_print()</code> prints out information about the entity element
 - <code>get_sub_entities(limit=10)</code> returns EntityCollection of all entities that derive from the current

--- a/spacy_entity_linker/EntityCollection.py
+++ b/spacy_entity_linker/EntityCollection.py
@@ -1,4 +1,6 @@
+import srsly
 from collections import Counter, defaultdict
+
 from .DatabaseConnection import get_wikidata_instance
 
 MAX_ITEMS_PREVIEW=20
@@ -70,3 +72,21 @@ class EntityCollection:
 
     def get_distinct_categories(self, max_depth=1):
         return list(set(self.get_categories(max_depth)))
+
+
+@srsly.msgpack_encoders("EntityCollection")
+def serialize_obj(obj, chain=None):
+    if isinstance(obj, EntityCollection):
+        return {
+            "entities": obj.entities,
+        }
+    # otherwise return the original object so another serializer can handle it
+    return obj if chain is None else chain(obj)
+
+
+@srsly.msgpack_decoders("EntityCollection")
+def deserialize_obj(obj, chain=None):
+    if "entities" in obj:
+        return EntityCollection(entities=obj["entities"])
+    # otherwise return the original object so another serializer can handle it
+    return obj if chain is None else chain(obj)

--- a/spacy_entity_linker/EntityElement.py
+++ b/spacy_entity_linker/EntityElement.py
@@ -1,8 +1,9 @@
+import spacy
 import srsly
 
 from .DatabaseConnection import get_wikidata_instance
 from .EntityCollection import EntityCollection
-
+from .SpanInfo import SpanInfo
 
 class EntityElement:
     def __init__(self, row, span):
@@ -25,7 +26,7 @@ class EntityElement:
             self.original_alias = row[5]
 
         self.url="https://www.wikidata.org/wiki/Q{}".format(self.get_id())
-        self.span = span
+        self.span_info = SpanInfo.from_span(span)
 
         self.chain = None
         self.chain_ids = None
@@ -41,8 +42,20 @@ class EntityElement:
     def is_singleton(self):
         return len(self.get_chain()) == 0
 
-    def get_span(self):
-        return self.span
+    def get_span(self, doc: spacy.tokens.Doc=None):
+        """
+        Returns the span of the entity in the document.
+        :param doc: the document in which the entity is contained
+        :return: the span of the entity in the document
+
+        If the doc is not None, it returns a real spacy.tokens.Span.
+        Otherwise it returns the instance of SpanInfo that emulates the behaviour of a spacy.tokens.Span
+        """
+        if doc is not None:
+            # return a real spacy.tokens.Span
+            return self.span_info.get_span(doc)
+        # otherwise return the instance of SpanInfo that emulates the behaviour of a spacy.tokens.Span
+        return self.span_info
 
     def get_label(self):
         return self.label
@@ -119,15 +132,15 @@ class EntityElement:
 
     def pretty_string(self, description=False):
         if description:
-            return ','.join([span.text for span in self.span]) + "  => {} <{}>".format(self.get_label(),
-                                                                                       self.get_description())
+            return "{}  => {} <{}>".format(self.span_info, self.get_label(), self.get_description())
         else:
-            return ','.join([span.text for span in self.span]) + "  => {}".format(self.get_label())
+            return "{}  => {}".format(self.span_info, self.get_label())
 
-    def save(self, category):
-        for span in self.span:
-            span.sent._.linked_entities.append(
-                {"id": self.identifier, "range": [span.start, span.end + 1], "category": category})
+    # TODO: this method has never worked because the custom attribute is not registered properly
+    # def save(self, category):
+    #     for span in self.span:
+    #         span.sent._.linked_entities.append(
+    #             {"id": self.identifier, "range": [span.start, span.end + 1], "category": category})
 
     def __str__(self):
         label = self.get_label()
@@ -150,8 +163,8 @@ def serialize_obj(obj, chain=None):
             "prior": obj.prior,
             "in_degree": obj.in_degree,
             "original_alias": obj.original_alias,
+            "span_info": obj.span_info,
         }
-        # TODO: understand how to serialize span
         return result
     # otherwise return the original object so another serializer can handle it
     return obj if chain is None else chain(obj)
@@ -161,8 +174,7 @@ def serialize_obj(obj, chain=None):
 def deserialize_obj(obj, chain=None):
     if "identifier" in obj:
         row = [obj['identifier'], obj['label'], obj['description'], obj['prior'], obj['in_degree'], obj['original_alias']]
-        # TODO: understand how to deserialize span
-        span = None
-        return EntityElement(row, span)
+        span_info = obj['span_info']
+        return EntityElement(row, span_info)
     # otherwise return the original object so another serializer can handle it
     return obj if chain is None else chain(obj)

--- a/spacy_entity_linker/EntityElement.py
+++ b/spacy_entity_linker/EntityElement.py
@@ -1,3 +1,5 @@
+import srsly
+
 from .DatabaseConnection import get_wikidata_instance
 from .EntityCollection import EntityCollection
 
@@ -8,6 +10,8 @@ class EntityElement:
         self.prior = 0
         self.original_alias = None
         self.in_degree = None
+        self.label = None
+        self.description = None
 
         if len(row) > 1:
             self.label = row[1]
@@ -134,3 +138,31 @@ class EntityElement:
 
     def __eq__(self, other):
         return isinstance(other, EntityElement) and other.get_id() == self.get_id()
+
+
+@srsly.msgpack_encoders("EntityElement")
+def serialize_obj(obj, chain=None):
+    if isinstance(obj, EntityElement):
+        result = {
+            "identifier": obj.identifier,
+            "label": obj.label,
+            "description": obj.description,
+            "prior": obj.prior,
+            "in_degree": obj.in_degree,
+            "original_alias": obj.original_alias,
+        }
+        # TODO: understand how to serialize span
+        return result
+    # otherwise return the original object so another serializer can handle it
+    return obj if chain is None else chain(obj)
+
+
+@srsly.msgpack_decoders("EntityElement")
+def deserialize_obj(obj, chain=None):
+    if "identifier" in obj:
+        row = [obj['identifier'], obj['label'], obj['description'], obj['prior'], obj['in_degree'], obj['original_alias']]
+        # TODO: understand how to deserialize span
+        span = None
+        return EntityElement(row, span)
+    # otherwise return the original object so another serializer can handle it
+    return obj if chain is None else chain(obj)

--- a/spacy_entity_linker/EntityElement.py
+++ b/spacy_entity_linker/EntityElement.py
@@ -26,7 +26,11 @@ class EntityElement:
             self.original_alias = row[5]
 
         self.url="https://www.wikidata.org/wiki/Q{}".format(self.get_id())
-        self.span_info = SpanInfo.from_span(span)
+        if span:
+            self.span_info = SpanInfo.from_span(span)
+        else:
+            # sometimes the constructor is called with None as second parameter (e.g. in get_sub_entities/get_super_entities)
+            self.span_info = None
 
         self.chain = None
         self.chain_ids = None

--- a/spacy_entity_linker/EntityLinker.py
+++ b/spacy_entity_linker/EntityLinker.py
@@ -24,10 +24,11 @@ class EntityLinker:
             entityCandidates = termCandidates.get_entity_candidates()
             if len(entityCandidates) > 0:
                 entity = classifier(entityCandidates)
+                span = doc[entity.span_info.start:entity.span_info.end]
                 # Add the entity to the sentence-level EntityCollection
-                entity.span.sent._.linkedEntities.append(entity)
+                span.sent._.linkedEntities.append(entity)
                 # Also associate the token span with the entity
-                entity.span._.linkedEntities = entity
+                span._.linkedEntities = entity
                 # And finally append to the document-level collection
                 entities.append(entity)
 

--- a/spacy_entity_linker/SpanInfo.py
+++ b/spacy_entity_linker/SpanInfo.py
@@ -1,0 +1,55 @@
+"""
+SpanInfo class
+Stores the info of spacy.tokens.Span (start, end and text of a span) by making it serializable
+"""
+
+import spacy
+import srsly
+
+class SpanInfo:
+
+    @staticmethod
+    def from_span(span: spacy.tokens.Span):
+        return SpanInfo(span.start, span.end, span.text)
+    
+    def __init__(self, start: int, end: int, text: str):
+        self.start = start
+        self.end = end
+        self.text = text
+
+
+    def __repr__(self) -> str:
+        return self.text
+    
+    def __len__(self):
+        return self.end - self.start
+    
+    def __eq__(self, __o: object) -> bool:
+        if isinstance(__o, SpanInfo):
+            return self.start == __o.start and self.end == __o.end and self.text == __o.text
+        return False
+    
+    def get_span(self, doc: spacy.tokens.Doc):
+        """
+        Returns the real spacy.tokens.Span of the doc from the stored info"""
+        return doc[self.start:self.end]
+
+
+@srsly.msgpack_encoders("SpanInfo")
+def serialize_spaninfo(obj, chain=None):
+    if isinstance(obj, SpanInfo):
+        result = {
+            "start": obj.start,
+            "end": obj.end,
+            "text": obj.text,
+        }
+        return result
+    # otherwise return the original object so another serializer can handle it
+    return obj if chain is None else chain(obj)
+
+@srsly.msgpack_decoders("SpanInfo")
+def deserialize_spaninfo(obj, chain=None):
+    if "start" in obj:
+        return SpanInfo(obj['start'], obj['end'], obj['text'])
+    # otherwise return the original object so another serializer can handle it
+    return obj if chain is None else chain(obj)

--- a/spacy_entity_linker/SpanInfo.py
+++ b/spacy_entity_linker/SpanInfo.py
@@ -25,7 +25,7 @@ class SpanInfo:
         return self.end - self.start
     
     def __eq__(self, __o: object) -> bool:
-        if isinstance(__o, SpanInfo):
+        if isinstance(__o, SpanInfo) or isinstance(__o, spacy.tokens.Span):
             return self.start == __o.start and self.end == __o.end and self.text == __o.text
         return False
     

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,0 +1,36 @@
+import unittest
+import spacy
+from multiprocessing.pool import ThreadPool
+
+
+class TestEntityElement(unittest.TestCase):
+
+    def __init__(self, arg, *args, **kwargs):
+        super(TestEntityElement, self).__init__(arg, *args, **kwargs)
+        self.nlp = spacy.load('en_core_web_sm')
+
+    def test_is_pipe_multiprocessing_safe(self):
+        self.nlp.add_pipe("entityLinker", last=True)
+
+        ents = [
+            'Apple',
+            'Microsoft',
+            'Google',
+            'Amazon',
+            'Facebook',
+            'IBM',
+            'Twitter',
+            'Tesla',
+            'SpaceX',
+            'Alphabet',
+        ]
+        text = "{} is looking at buying U.K. startup for $1 billion"
+
+        texts = [text.format(ent) for ent in ents]
+        docs = self.nlp.pipe(texts, n_process=2)
+        for doc in docs:
+            print(doc)
+            for ent in doc.ents:
+                print(ent.text, ent.label_, ent._.linkedEntities)
+
+        self.nlp.remove_pipe("entityLinker")

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -3,10 +3,10 @@ import spacy
 from multiprocessing.pool import ThreadPool
 
 
-class TestEntityElement(unittest.TestCase):
+class TestMultiprocessing(unittest.TestCase):
 
     def __init__(self, arg, *args, **kwargs):
-        super(TestEntityElement, self).__init__(arg, *args, **kwargs)
+        super(TestMultiprocessing, self).__init__(arg, *args, **kwargs)
         self.nlp = spacy.load('en_core_web_sm')
 
     def test_is_pipe_multiprocessing_safe(self):

--- a/tests/test_multithreading.py
+++ b/tests/test_multithreading.py
@@ -3,10 +3,10 @@ import spacy
 from multiprocessing.pool import ThreadPool
 
 
-class TestEntityElement(unittest.TestCase):
+class TestMultiThreading(unittest.TestCase):
 
     def __init__(self, arg, *args, **kwargs):
-        super(TestEntityElement, self).__init__(arg, *args, **kwargs)
+        super(TestMultiThreading, self).__init__(arg, *args, **kwargs)
         self.nlp = spacy.load('en_core_web_sm')
 
     def test_is_multithread_safe(self):

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -1,0 +1,37 @@
+import unittest
+import spacy
+from multiprocessing.pool import ThreadPool
+
+
+class TestPipe(unittest.TestCase):
+
+    def __init__(self, arg, *args, **kwargs):
+        super(TestPipe, self).__init__(arg, *args, **kwargs)
+        self.nlp = spacy.load('en_core_web_sm')
+
+    def test_serialize(self):
+        self.nlp.add_pipe("entityLinker", last=True)
+
+        ents = [
+            'Apple',
+            'Microsoft',
+            'Google',
+            'Amazon',
+            'Facebook',
+            'IBM',
+            'Twitter',
+            'Tesla',
+            'SpaceX',
+            'Alphabet',
+        ]
+        text = "{} is looking at buying U.K. startup for $1 billion"
+
+        texts = [text.format(ent) for ent in ents]
+        docs = self.nlp.pipe(texts, n_process=2)
+        for doc in docs:
+            print(doc)
+            for ent in doc.ents:
+                print(ent.text, ent.label_, ent._.linkedEntities)
+
+
+        self.nlp.remove_pipe("entityLinker")

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,33 @@
+import unittest
+import spacy
+from multiprocessing.pool import ThreadPool
+
+
+class TestSerialize(unittest.TestCase):
+
+    def __init__(self, arg, *args, **kwargs):
+        super(TestSerialize, self).__init__(arg, *args, **kwargs)
+        self.nlp = spacy.load('en_core_web_sm')
+
+    def test_serialize(self):
+        self.nlp.add_pipe("entityLinker", last=True)
+
+        text = "Apple is looking at buying U.K. startup for $1 billion"
+        doc = self.nlp(text)
+        serialised = doc.to_bytes()
+
+        doc2 = spacy.tokens.Doc(doc.vocab).from_bytes(serialised)
+        for ent, ent2 in zip(doc.ents, doc2.ents):
+            assert ent.text == ent2.text
+            assert ent.label_ == ent2.label_
+            linked = ent._.linkedEntities
+            linked2 = ent2._.linkedEntities
+            if linked:
+                assert linked.get_description() == linked2.get_description()
+                assert linked.get_id() == linked2.get_id()
+                assert linked.get_label() == linked2.get_label()
+                assert linked.get_span() == linked2.get_span()
+                assert linked.get_url() == linked2.get_url()
+
+
+        self.nlp.remove_pipe("entityLinker")


### PR DESCRIPTION
With this PR, it is now possible to serialize and therefore use multiprocessing/pipe.

This PR solves: #23 and #7

Solution used:
calling `EntityElement.get_span()` now provides as a result an object belonging to the SpanInfo class. 
These objects are serializable, while `spacy.tokens.Span` is not serializable.

Similarity:
This class emulates the behaviour of `spacy.tokens.Span` (`__repr__`, `__len__`, `__eq__`).
You can for example check if `ent1 == ent2` and it will compare start, end and text as `spacy.tokens.Span`.

Difference:
The objects of `SpanInfo` do not contain references to the `doc` object (also this one is not serializable) and therefore you cannot perform `ent.get_span().sent` or `ent.get_span().doc`. If you really need to get a reference to the real `Span`, you need to pass `doc` as an argument to the `.get_span(doc)` method. In this way you can perform `ent.get_span(doc).sent`.

```python
import spacy
nlp = spacy.load('en_core_web_md')
nlp.add_pipe("entityLinker", last=True)
text = 'Apple is competing with Microsoft.'
doc = nlp(text)
ent = doc._.linkedEntities[0]

# as before, but this is an instance of the SpanInfo class
span = ent.get_span()
print(span.start, span.end, span.text) # everything normal

# check equivalence
print(span == doc[0:1]) # True, normal
print(doc[0:1] == span) # TypeError: Argument 'other' has incorrect type (expected spacy.tokens.span.Span, got SpanInfo)

# now get the real span
span = ent.get_span(doc) # passing the doc instance here
print(span.start, span.end, span.text)

print(span == doc[0:1]) # True
print(doc[0:1] == span) # True
```

With the recently added tests, it shows no problems.

Since it is slightly breaking the API, I would like to double-check with someone before merging (e.g. @dennlinger if you have any thoughts about this change for the `.get_span()` method).

Best,
Martino
